### PR TITLE
Replace SSL with TLS

### DIFF
--- a/EditorsDraft/edit.html
+++ b/EditorsDraft/edit.html
@@ -3199,7 +3199,7 @@ The response SHOULD also include the `Retry-After` HTTP Header with a value set 
 
 ## Security
 
-Although this specification does not mandate a specific means of securing an API, it does mandate that at a minimum all HTTP requests and responses MUST be secured using SSL.
+Although this specification does not mandate a specific means of securing an API, it does mandate that at a minimum all HTTP requests and responses MUST be secured using TLS.
 
 
 ## Authentication


### PR DESCRIPTION
```
$ grep -rEi '\bSSL\b' EditorsDraft/
EditorsDraft/index-interim.html:All HTTP requests and responses SHOULD be secured using SSL.
EditorsDraft/edit.html:Although this specification does not mandate a specific means of securing an API, it does mandate that at a minimum all HTTP requests and responses MUST be secured using SSL.
EditorsDraft/edit-old.html:All HTTP requests and responses SHOULD be secured using SSL.
EditorsDraft/index-old.html:All HTTP requests and responses SHOULD be secured using SSL.
```